### PR TITLE
Fix dynamic analyzer container loop

### DIFF
--- a/src/modules/dynamic_analysis/dynamic_analyzer.py
+++ b/src/modules/dynamic_analysis/dynamic_analyzer.py
@@ -65,10 +65,11 @@ class DynamicAnalyzer:
             start_time = time.time()
             try:
                 while time.time() - start_time < timeout:
-                    if container.status == 'exited':
+                    container.reload()  # refresh container status
+                    if container.status in ("exited", "dead"):
                         break
                     time.sleep(0.1)
-            except:
+            except Exception:
                 pass
             
             # Collect results


### PR DESCRIPTION
## Summary
- refresh Docker container status during dynamic analysis

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'r2pipe')*

------
https://chatgpt.com/codex/tasks/task_e_684082dc3a70832eacb0e776b90c976a